### PR TITLE
Remove empty schema if it doesn't contains operations or prefixes

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -27,6 +27,7 @@
     - [remove_operations_by_space_name()](#remove_operations_by_space_name)
     - [on_resolve()](#on_resolve)
     - [remove_on_resolve_triggers()](#remove_on_resolve_triggers)
+    - [is_schema_empty()](#is_schema_empty)
 
 Submodule `operations.lua` - is a part of GraphQL API module provided functions to add/remove queries, mutations and it's prefixes as well as subsidiary functions to deal with GraphQL operations.
 
@@ -235,7 +236,11 @@ Example:
 
 ### queries_list()
 
-`operations.queries_list()` - method is used to get list of registered queries,
+`operations.queries_list(schema_name)` - method is used to get list of registered queries,
+
+where:
+
+- `schema_name` (`string`) - optional, schema name, if nil - then default schema is used [Default schema](defaults.md#default_schema_name),
 
 returns:
 
@@ -311,7 +316,11 @@ Example:
 
 ### mutations_list()
 
-`operations.mutations_list()` - method is used to get list of registered queries,
+`operations.mutations_list(schema_name)` - method is used to get list of registered queries,
+
+where:
+
+- `schema_name` (`string`) - optional, schema name, if nil - then default schema is used [Default schema](defaults.md#default_schema_name),
 
 returns:
 
@@ -553,3 +562,15 @@ Example:
 ### remove_on_resolve_triggers()
 
 `operations.remove_on_resolve_triggers()` - method to remove all GraphQL API triggers at once.
+
+### is_schema_empty()
+
+`operations.is_schema_empty(schema_name)` - method is used to check if schema contains at least one of: query, mutation, queries_prefix, mutations_prefix,
+
+where:
+
+- `schema_name` (`string`) - optional, schema name, if nil - then default schema is used [Default schema](defaults.md#default_schema_name),
+
+returns:
+
+- `is_schema_empty` (`boolean`) - If `true` - schema is empty and if `false` - schema contains at least one of: query, mutation, queries_prefix, mutations_prefix.

--- a/graphqlapi/operations.lua
+++ b/graphqlapi/operations.lua
@@ -32,6 +32,17 @@ local function funcall_wrap(fun_name, operation_type, operation_schema, operatio
     end
 end
 
+local function is_schema_empty(schema)
+    schema = utils.coerce_schema(schema)
+
+    local all_operations = utils.count_map(_queries[schema])
+    all_operations = all_operations + utils.count_map(_mutations[schema])
+    if all_operations == 0 then
+        return true
+    end
+    return false
+end
+
 local function add_queries_prefix(opts)
     checks({
         prefix = 'string',
@@ -125,7 +136,7 @@ local function remove_queries_prefix(opts)
         end
     end
 
-    schemas.set_invalid(opts.schema)
+    schemas.set_invalid(opts.schema, is_schema_empty(opts.schema))
 end
 
 local function add_mutations_prefix(opts)
@@ -221,7 +232,7 @@ local function remove_mutations_prefix(opts)
             end
         end
     end
-    schemas.set_invalid(opts.schema)
+    schemas.set_invalid(opts.schema, is_schema_empty(opts.schema))
 end
 
 local function add_query(opts)
@@ -345,7 +356,7 @@ local function remove_query(opts)
         end
     end
 
-    schemas.set_invalid(opts.schema)
+    schemas.set_invalid(opts.schema, is_schema_empty(opts.schema))
 end
 
 local function queries_list(schema_name)
@@ -486,7 +497,7 @@ local function remove_mutation(opts)
         end
     end
 
-    schemas.set_invalid(opts.schema)
+    schemas.set_invalid(opts.schema, is_schema_empty(opts.schema))
 end
 
 local function mutations_list(schema_name)
@@ -612,7 +623,7 @@ local function remove_space_query(opts)
                 end
             end
             table.remove(_space_query[opts.space], index)
-            schemas.set_invalid(opts.schema)
+            schemas.set_invalid(opts.schema, is_schema_empty(opts.schema))
         end
     else
         opts.schema = utils.coerce_schema(opts.schema)
@@ -735,7 +746,7 @@ local function remove_space_mutation(opts)
                 end
             end
             table.remove(_space_mutation[opts.space], index)
-            schemas.set_invalid(opts.schema)
+            schemas.set_invalid(opts.schema, is_schema_empty(opts.schema))
         end
     else
         opts.schema = utils.coerce_schema(opts.schema)
@@ -815,7 +826,7 @@ local function remove_operations_by_space_name(space_name)
             end
         end
 
-        schemas.set_invalid(query.schema)
+        schemas.set_invalid(query.schema, is_schema_empty(query.schema))
     end
 
     _space_query[space_name] = nil
@@ -835,7 +846,7 @@ local function remove_operations_by_space_name(space_name)
             end
         end
 
-        schemas.set_invalid(mutation.schema)
+        schemas.set_invalid(mutation.schema, is_schema_empty(mutation.schema))
     end
     _space_mutation[space_name] = nil
 end
@@ -870,6 +881,7 @@ return {
     remove_all = remove_all,
     get_queries = get_queries,
     get_mutations = get_mutations,
+    is_schema_empty = is_schema_empty,
 
     -- Queries prefixes API
     add_queries_prefix = add_queries_prefix,

--- a/graphqlapi/schemas.lua
+++ b/graphqlapi/schemas.lua
@@ -16,19 +16,24 @@ local function reset_invalid(schema)
     _schema_invalid[schema] = false
 end
 
-local function set_invalid(schema)
-    checks('?string')
+local function set_invalid(schema, remove)
+    checks('?string', '?boolean')
+
+    schema = utils.coerce_schema(schema)
 
     if graphqlide_ok == true then
-        local endpoints = graphqlide.get_endpoints()
-        local endpoint = rawget(_G, '__GRAPHQLAPI_ENDPOINT')
-        if endpoints ~= nil and type(endpoints) == 'table' and
-           endpoints[schema] == nil and endpoint ~= nil then
-            graphqlide.set_endpoint({ name = schema, path = endpoint })
+        if remove then
+            graphqlide.remove_endpoint(schema)
+        else
+            local endpoints = graphqlide.get_endpoints()
+            local endpoint = rawget(_G, '__GRAPHQLAPI_ENDPOINT')
+            if endpoints ~= nil and type(endpoints) == 'table' and
+            endpoints[schema] == nil and endpoint ~= nil then
+                graphqlide.set_endpoint({ name = schema, path = endpoint })
+            end
         end
     end
 
-    schema = utils.coerce_schema(schema)
     _schema_invalid[schema] = true
 end
 

--- a/graphqlapi/utils.lua
+++ b/graphqlapi/utils.lua
@@ -251,6 +251,15 @@ local function get_tnt_version()
     return version
 end
 
+local function count_map(t)
+    if t ~= nil and type(t) == 'table' then
+        local count = 0
+        for _ in pairs(t) do count = count + 1 end
+        return count
+    end
+    return 0
+end
+
 return {
     value_in = value_in,
     diff_maps = diff_maps,
@@ -270,4 +279,5 @@ return {
     to_compat = to_compat,
     from_compat = from_compat,
     get_tnt_version = get_tnt_version,
+    count_map = count_map,
 }

--- a/test/unit/operations_test.lua
+++ b/test/unit/operations_test.lua
@@ -9,11 +9,13 @@ local types = require('graphqlapi.types')
 g.before_each(function()
     types.remove_all()
     operations.remove_all()
+    assert(operations.is_schema_empty("test_schema"))
 end)
 
 g.after_each(function()
     types.remove_all()
     operations.remove_all()
+    assert(operations.is_schema_empty("test_schema"))
 end)
 
 g.test_add_remove_query_default_schema_no_prefix = function()
@@ -178,6 +180,8 @@ g.test_add_remove_query_default_schema_with_prefix = function()
 end
 
 g.test_add_remove_query_custom_schema_no_prefix = function()
+    t.assert_equals(operations.is_schema_empty('test_schema'), true)
+
     operations.add_query({
         schema = 'test_schema',
         name = 'entity',
@@ -189,6 +193,8 @@ g.test_add_remove_query_custom_schema_no_prefix = function()
         callback = 'fragments.entity.entity_get',
     })
 
+    t.assert_equals(operations.is_schema_empty('test_schema'), false)
+
     t.assert_equals(type(operations.get_queries('test_schema')['entity']), 'table')
     t.assert_equals(operations.get_queries('test_schema')['entity'].description, 'Get entity')
     t.assert_equals(schemas.is_invalid('test_schema'), true)
@@ -199,6 +205,7 @@ g.test_add_remove_query_custom_schema_no_prefix = function()
     t.assert_items_equals(operations.queries_list('test_schema'), {'entity'})
 
     operations.remove_query({name = 'entity', schema = 'test_schema'})
+    t.assert_equals(operations.is_schema_empty('test_schema'), true)
 
     t.assert_equals(operations.get_queries('test_schema')['entity'], nil)
 
@@ -208,6 +215,7 @@ g.test_add_remove_query_custom_schema_no_prefix = function()
 end
 
 g.test_add_remove_query_custom_schema_with_prefix = function()
+    t.assert_equals(operations.is_schema_empty('test_schema'), true)
     operations.add_queries_prefix({
         prefix = 'test',
         schema = 'test_schema',
@@ -234,6 +242,7 @@ g.test_add_remove_query_custom_schema_with_prefix = function()
         kind = types.string,
         callback = 'fragments.entity.entity_1_get',
     })
+    t.assert_equals(operations.is_schema_empty('test_schema'), false)
 
     t.assert_equals(type(operations.get_queries('test_schema')['test'].kind.fields['entity_1']), 'table')
     t.assert_equals(operations.get_queries('test_schema')['test'].kind.fields['entity_1'].description, 'Get entity 1')
@@ -269,7 +278,7 @@ g.test_add_remove_query_custom_schema_with_prefix = function()
         schema = 'test_schema',
         prefix = 'test',
     })
-
+    t.assert_equals(operations.is_schema_empty('test_schema'), false)
     t.assert_equals(type(operations.get_queries('test_schema')['test'].kind.fields['entity_2']), 'table')
     t.assert_equals(operations.get_queries('test_schema')['test'].kind.fields['entity_2'].description, 'Get entity 2')
     t.assert_equals(schemas.is_invalid('test_schema'), true)
@@ -300,6 +309,7 @@ g.test_add_remove_query_custom_schema_with_prefix = function()
 end
 
 g.test_add_remove_mutation_default_schema_no_prefix = function()
+    t.assert_equals(operations.is_schema_empty(), true)
     operations.add_mutation({
         name = 'entity',
         doc = 'Mutate entity',
@@ -310,6 +320,7 @@ g.test_add_remove_mutation_default_schema_no_prefix = function()
         callback = 'fragments.entity.entity_set',
     })
 
+    t.assert_equals(operations.is_schema_empty(), false)
     t.assert_equals(operations.is_mutation_exists({ name = 'entity', }), true)
     t.assert_equals(type(operations.get_mutations()['entity']), 'table')
     t.assert_equals(operations.get_mutations()['entity'].description, 'Mutate entity')
@@ -337,6 +348,7 @@ g.test_add_remove_mutation_default_schema_no_prefix = function()
 
 
     operations.remove_mutation({ name = 'entity' })
+    t.assert_equals(operations.is_schema_empty(), true)
     t.assert_equals(operations.get_mutations()['entity'], nil)
 
     t.assert_equals(schemas.is_invalid(), true)
@@ -345,6 +357,7 @@ g.test_add_remove_mutation_default_schema_no_prefix = function()
 end
 
 g.test_add_remove_mutation_default_schema_with_prefix = function()
+    t.assert_equals(operations.is_schema_empty(), true)
     operations.add_mutations_prefix({
         prefix = 'test',
         doc = 'Simple prefix test',
@@ -368,6 +381,7 @@ g.test_add_remove_mutation_default_schema_with_prefix = function()
 
     t.assert_equals(ok, false)
     t.assert_equals(err, 'mutation or prefix with name "test" already exists in schema: "Default"')
+    t.assert_equals(operations.is_schema_empty(), false)
 
     operations.add_mutation({
         prefix = 'test',
@@ -380,6 +394,7 @@ g.test_add_remove_mutation_default_schema_with_prefix = function()
         callback = 'fragments.entity.entity_1_set',
     })
 
+    t.assert_equals(operations.is_schema_empty(), false)
     t.assert_equals(operations.is_mutation_exists({ prefix = 'test', name = 'entity_1', }), true)
     t.assert_equals(type(operations.get_mutations()['test'].kind.fields['entity_1']), 'table')
     t.assert_equals(operations.get_mutations()['test'].kind.fields['entity_1'].description, 'Mutate entity 1')

--- a/test/unit/utils_test.lua
+++ b/test/unit/utils_test.lua
@@ -298,3 +298,16 @@ g.test_get_tnt_version = function()
 
     rawset(_G, '_TARANTOOL', version)
 end
+
+g.test_count_map = function()
+    t.assert_equals(utils.count_map(), 0)
+    t.assert_equals(utils.count_map(''), 0)
+    t.assert_equals(utils.count_map({}), 0)
+    t.assert_equals(utils.count_map({'1', 1, ['1'] = {1}}), 3)
+    t.assert_equals(utils.count_map(
+        {
+            ['space2'] = {name = 'space2', schema = 'default', prefix = 'spaces'},
+            ['space1'] = {name = 'space1', schema = 'default', prefix = 'spaces'},
+        }
+    ), 2)
+end


### PR DESCRIPTION
Automatically remove empty schema from graphqlide registry if schema doesn't contains any operations or prefixes