### PR TITLE
Release 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.5
 
 - `rename errors class in cluster submodule`
 - `rename specifiedByUrl to specifiedBy`


### PR DESCRIPTION
- `rename errors class in cluster submodule`
- `rename specifiedByUrl to specifiedBy`
- `use vanilla graphql lib`
- `fixed not injecting module version in release workflow`
- `remove empty schema if it doesn't contain operations or prefixes`
- `actualize examples`