### PR TITLE
Fix coercing default values on schema generation

### DIFF
--- a/graphqlapi/graphql/schema.lua
+++ b/graphqlapi/graphql/schema.lua
@@ -70,6 +70,7 @@ function schema:generateTypeMap(node)
 
   if node.__type == 'Object' or node.__type == 'Interface' or node.__type == 'InputObject' then
     for fieldName, field in pairs(node.fields) do
+      local defaultValue = field.defaultValue
       if field.arguments then
         for name, argument in pairs(field.arguments) do
           -- BEGIN_HACK: resolve type names to real types
@@ -85,12 +86,14 @@ function schema:generateTypeMap(node)
 
           local argumentType = argument.__type and argument or argument.kind
           assert(argumentType, 'Must supply type for argument "' .. name .. '" on "' .. fieldName .. '"')
+          argumentType.defaultValue = argument.defaultValue
           self:generateTypeMap(argumentType)
         end
       end
 
       -- HACK: resolve type names to real types
       field.kind = types.resolve(field.kind, self.name)
+      field.defaultValue = defaultValue
       self:generateTypeMap(field.kind)
     end
   end

--- a/graphqlapi/graphql/types.lua
+++ b/graphqlapi/graphql/types.lua
@@ -224,6 +224,7 @@ function types.inputObject(config)
       name = fieldName,
       kind = field.kind,
       description = field.description,
+      defaultValue = field.defaultValue,
     }
   end
 

--- a/test/integration/graphql_integration_test.lua
+++ b/test/integration/graphql_integration_test.lua
@@ -1537,3 +1537,39 @@ function g.test_descriptions()
     local input_object_arg_described = util.find_by_name(test_input_object.inputFields, 'input_object_arg_described')
     t.assert_equals(input_object_arg_described.description, 'input object argument')
 end
+
+function g.test_arguments_default_values()
+    local function callback(_, _)
+        return nil
+    end
+
+    local mutation_schema = {
+        ['test_mutation'] = {
+            kind = types.string.nonNull,
+            arguments = {
+                mutation_arg = types.string,
+                mutation_arg_defaults = {
+                    kind = types.inputObject({
+                        name = 'test_input_object',
+                        fields = {
+                            input_object_arg_defaults = {
+                                kind = types.string,
+                                defaultValue = 'input object argument default value'
+                            },
+                            input_object_arg = types.string,
+                        },
+                        kind = types.string,
+                    }),
+                },
+            },
+            resolve = callback,
+        }
+    }
+
+    local data, errors = check_request(introspection.query, nil, mutation_schema)
+    t.assert_equals(errors, nil)
+
+    local test_input_object = util.find_by_name(data.__schema.types, 'test_input_object')
+    local input_object_arg_defaults = util.find_by_name(test_input_object.inputFields, 'input_object_arg_defaults')
+    t.assert_equals(input_object_arg_defaults.defaultValue, 'input object argument default value')
+end


### PR DESCRIPTION
Before this patch:
- defaultValue were not saved on inputObject creation
- on schema generation defaultValue were not propagated