### PR TITLE
Release 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.8
+
+- `update examples dependencies: graphqlide@0.0.18 ->  graphqlide@0.0.19, graphqlapi@0.0.7 -> graphqlapi@0.0.8, graphqlapi-helpers@0.0.7 -> graphqlapi-helpers@0.0.8`
+
 ## 0.0.7
 
 - `add utils.cache_get() and utils.cache_set() methods`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Module based on:
 - [Tarantool VShard 0.1.18+](https://github.com/tarantool/vshard)
 - [Tarantool Checks 1.1.0+](https://github.com/tarantool/checks)
 - [Tarantool Errors 2.1.3+](https://github.com/tarantool/errors)
-- [Tarantool GraphQLIDE 0.0.18+](https://github.com/tarantool/graphqlide)
+- [Tarantool GraphQLIDE 0.0.19+](https://github.com/tarantool/graphqlide)
 
 **CAUTION:** Since this module is under heavy development it is not recommended to use on production environments and also API and functionality in future releases may be changed without backward compatibility!
 

--- a/examples/cartridge-full/README.md
+++ b/examples/cartridge-full/README.md
@@ -2,9 +2,9 @@
 
 This Example shows mostly all base capabilities of using the following set of modules:
 
-- [Tarantool GraphQLIDE 0.0.18+](https://github.com/tarantool/graphqlide)
-- [Tarantool GraphQLAPI 0.0.7+](https://github.com/tarantool/graphqlapi)
-- [Tarantool GraphQLAPI Helpers 0.0.7+](https://github.com/tarantool/graphqlapi-helpers) - this particular module available only in Tarantool Enterprise SDK bundle
+- [Tarantool GraphQLIDE 0.0.19+](https://github.com/tarantool/graphqlide)
+- [Tarantool GraphQLAPI 0.0.8+](https://github.com/tarantool/graphqlapi)
+- [Tarantool GraphQLAPI Helpers 0.0.8+](https://github.com/tarantool/graphqlapi-helpers) - this particular module available only in Tarantool Enterprise SDK bundle
 
 ## Quick start
 

--- a/examples/cartridge-full/cartridge.pre-build
+++ b/examples/cartridge-full/cartridge.pre-build
@@ -11,6 +11,6 @@ tarantoolctl rocks remove graphqlide --force
 tarantoolctl rocks remove graphqlapi --force
 tarantoolctl rocks remove graphqlapi-helpers --force
 
-tarantoolctl rocks install graphqlide 0.0.18
-tarantoolctl rocks install graphqlapi 0.0.7
-tarantoolctl rocks install graphqlapi-helpers 0.0.7
+tarantoolctl rocks install graphqlide 0.0.19
+tarantoolctl rocks install graphqlapi 0.0.8
+tarantoolctl rocks install graphqlapi-helpers 0.0.8

--- a/examples/cartridge-simple/README.md
+++ b/examples/cartridge-simple/README.md
@@ -2,9 +2,9 @@
 
 This Example shows simple and quite easy way of howto use set of modules in application:
 
-- [Tarantool GraphQLIDE 0.0.18+](https://github.com/tarantool/graphqlide)
-- [Tarantool GraphQLAPI 0.0.7+](https://github.com/tarantool/graphqlapi)
-- [Tarantool GraphQLAPI Helpers 0.0.7+](https://github.com/tarantool/graphqlapi-helpers) - this particular module available only in Tarantool Enterprise SDK bundle
+- [Tarantool GraphQLIDE 0.0.19+](https://github.com/tarantool/graphqlide)
+- [Tarantool GraphQLAPI 0.0.8+](https://github.com/tarantool/graphqlapi)
+- [Tarantool GraphQLAPI Helpers 0.0.8+](https://github.com/tarantool/graphqlapi-helpers) - this particular module available only in Tarantool Enterprise SDK bundle
 
 ## Quick start
 

--- a/examples/cartridge-simple/cartridge.pre-build
+++ b/examples/cartridge-simple/cartridge.pre-build
@@ -11,6 +11,6 @@ tarantoolctl rocks remove graphqlide --force
 tarantoolctl rocks remove graphqlapi --force
 tarantoolctl rocks remove graphqlapi-helpers --force
 
-tarantoolctl rocks install graphqlide 0.0.18
-tarantoolctl rocks install graphqlapi 0.0.7
-tarantoolctl rocks install graphqlapi-helpers 0.0.7
+tarantoolctl rocks install graphqlide 0.0.19
+tarantoolctl rocks install graphqlapi 0.0.8
+tarantoolctl rocks install graphqlapi-helpers 0.0.8


### PR DESCRIPTION
- `update examples dependencies: graphqlide@0.0.18 ->  graphqlide@0.0.19, graphqlapi@0.0.7 -> graphqlapi@0.0.8, graphqlapi-helpers@0.0.7 -> graphqlapi-helpers@0.0.8`