### PR TITLE
Remove redundant double custom scalar

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -18,7 +18,6 @@
     - [inputObject()](#inputobject)
     - [interface()](#interface)
     - [union()](#union)
-    - [double](#double)
     - [any](#any)
     - [map](#map)
     - [mapper](#mapper)
@@ -375,10 +374,6 @@ returns:
   - `name` (`string`) - union name;
   - `types` (`table`) - list of any valid GraphQL types.
 
-### double
-
-`types.double` - is a custom GraphQL scalar represents signed double-precision finite values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).
-
 ### any
 
 `types.any` - custom GraphQL scalar type represents any of the following scalars:
@@ -406,7 +401,7 @@ returns:
         ['array'] = { ['type'] = types.list(types.any), name = 'List', },
         ['boolean'] = { ['type'] = types.boolean, name = 'Boolean', },
         ['decimal'] = { ['type'] = types.long, name = 'Long', },
-        ['double'] = { ['type'] = types.double, name = 'Double', },
+        ['double'] = { ['type'] = types.float, name = 'Float', },
         ['integer'] = { ['type'] = types.long, name = 'Long', },
         ['map'] = { ['type'] = types.map, name = 'Map', },
         ['number'] = { ['type'] = types.float, name = 'Float', },

--- a/graphqlapi/types.lua
+++ b/graphqlapi/types.lua
@@ -93,30 +93,12 @@ types.union = function(config)
     return instance
 end
 
-types.double = types.scalar({
-    name = 'Double',
-    description = 'The `Double` scalar according to IEEE Standard for Floating-Point Arithmetic (IEEE 754)',
-    specifiedByURL = 'https://github.com/tarantool/graphqlapi/wiki/Double',
-    serialize = tonumber,
-    parseValue = tonumber,
-    parseLiteral = function(node)
-      -- 'float' and 'int' are names of immediate value types
-      if node.kind == 'float' or node.kind == 'int' then
-        return tonumber(node.value)
-      end
-    end,
-    isValueOfTheType = function(value)
-      return type(value) == 'number'
-    end,
-})
-
 local function parseNullLiteral(_)
     return box.NULL
 end
 
 local scalar_kind_to_parse = {
     boolean = types.boolean.parseLiteral,
-    double = types.double.parseLiteral,
     float = types.float.parseLiteral,
     int = types.long.parseLiteral,
     long = types.long.parseLiteral,
@@ -184,7 +166,7 @@ types.mapper = setmetatable({
     ['array'] = { ['type'] = types.list(types.any), name = 'List', },
     ['boolean'] = { ['type'] = types.boolean, name = 'Boolean', },
     ['decimal'] = { ['type'] = types.long, name = 'Long', },
-    ['double'] = { ['type'] = types.double, name = 'Double', },
+    ['double'] = { ['type'] = types.float, name = 'Float', },
     ['integer'] = { ['type'] = types.long, name = 'Long', },
     ['map'] = { ['type'] = types.map, name = 'Map', },
     ['number'] = { ['type'] = types.float, name = 'Float', },

--- a/test/integration/graphql_integration_test.lua
+++ b/test/integration/graphql_integration_test.lua
@@ -1732,25 +1732,6 @@ function g.test_specifiedByURL_long_scalar()
     t.assert_equals(errors, nil)
 end
 
-function g.test_specifiedByURL_double_scalar()
-    local query_schema = {
-        ['test'] = {
-            kind = types.string.nonNull,
-            arguments = {
-                arg = graphqlapi_types.double,
-            },
-            resolve = '',
-        }
-    }
-
-    local data, errors = check_request(introspection.query, query_schema)
-
-    local double_type_schema = util.find_by_name(data.__schema.types, 'Double')
-    t.assert_type(double_type_schema, 'table', 'Double scalar type not found on introspection')
-    t.assert_equals(double_type_schema.specifiedByURL, 'https://github.com/tarantool/graphqlapi/wiki/Double')
-    t.assert_equals(errors, nil)
-end
-
 function g.test_specifiedByURL_any_scalar()
     local query_schema = {
         ['test'] = {

--- a/test/unit/types_test.lua
+++ b/test/unit/types_test.lua
@@ -138,25 +138,6 @@ g.test_union = function()
     t.assert_str_contains(err, 'union "CatOrDog" already exists in schema: "Default"')
 end
 
-g.test_double = function()
-    local double = types.double
-    t.assert_equals(double.__type, 'Scalar')
-    t.assert_equals(double.name, 'Double')
-    local double_test_suite = {
-        {'int', '123', 123, }, {'int', '-123', -123, }, {'float', '0.0', 0.0},
-        {'float', '-0.0', -0.0}, {'float', '12.34', 12.34}, {'float', '1e0', 1e0},
-        {'float', '1e3', 1e3}, {'float', '1.0e3', 1.0e3}, {'float', '1.0e+3', 1.0e+3},
-        {'float', '1.0e-3', 1.0e-3}, {'float', '1.00e-30', 1.00e-30},
-    }
-
-    for _, ts in pairs(double_test_suite) do
-        t.assert_equals(double.serialize(ts[2]), ts[3])
-        t.assert_equals(double.parseValue(ts[2]), ts[3])
-        t.assert_equals(double.parseLiteral({kind = ts[1], value = ts[2]}), ts[3])
-        t.assert_equals(double.isValueOfTheType(ts[3]), true)
-    end
-end
-
 g.test_any = function()
     local any = types.any
     t.assert_equals(any.__type, 'Scalar')
@@ -533,7 +514,7 @@ g.test_get_non_leaf_types = function()
                                 name = 'alsoComplicated',
                                 fields = {
                                     x = types.string,
-                                    y = types.double,
+                                    y = types.float, -- //
                                 },
                                 arguments = {
                                     dogCommand = dogCommand.nonNull,
@@ -843,7 +824,7 @@ g.test_remove_recursive = function()
                                 name = 'alsoComplicated',
                                 fields = {
                                     x = types.string,
-                                    y = types.double,
+                                    y = types.float, -- //
                                 }
                             })
                         },


### PR DESCRIPTION
Default graphQL Float type is really double precision float. Thus double is redundunt and may be removed.