### PR TITLE
Fix coerse scalar list variables

### DIFF
--- a/graphqlapi/graphql/util.lua
+++ b/graphqlapi/graphql/util.lua
@@ -115,6 +115,11 @@ local function coerceValue(node, schemaType, variables, opts)
             node.name.value, variables[node.name.value], schemaType.name
         ))
       end
+    elseif type(value) == 'table' and schemaType.__type == 'List' and
+           type(schemaType.ofType) == 'table' and schemaType.ofType.parseValue ~= nil then
+      for k, v in ipairs(value) do
+        value[k] = schemaType.ofType.parseValue(v)
+      end
     end
     return value
   end

--- a/test/integration/graphql_integration_test.lua
+++ b/test/integration/graphql_integration_test.lua
@@ -563,25 +563,25 @@ function g.test_custom_type_scalar_variables()
                 if args.field == nil then
                     return nil
                 end
-                assert(type(args.field) == 'table', "Field is not a table! ")
-                assert(args.field.test ~= nil, "No field 'test' in object!")
+                t.assert_type(args.field, 'table', "Field is not a table! ")
+                t.assert_not_equals(args.field.test, nil, "No field 'test' in object!")
                 return args.field
             end
         },
-        -- ['test_json_type_list'] = {
-        --     arguments = {
-        --         array = types.list(json_type),
-        --     },
-        --     kind = types.list(json_type),
-        --     resolve = function(_, args)
-        --         if args.array == nil then
-        --             return nil
-        --         end
-        --         t.assert_type(args.array[1], 'table', "Array element is not a table! ")
-        --         t.assert_not_equals(args.array[1].test, nil, "No field 'test' in array element!")
-        --         return args.array
-        --     end
-        -- },
+        ['test_json_type_list'] = {
+            arguments = {
+                array = types.list(json_type),
+            },
+            kind = types.list(json_type),
+            resolve = function(_, args)
+                if args.array == nil then
+                    return nil
+                end
+                t.assert_type(args.array[1], 'table', "Array element is not a table! ")
+                t.assert_not_equals(args.array[1].test, nil, "No field 'test' in array element!")
+                return args.array
+            end
+        },
         ['test_custom_type_scalar_list'] = {
             kind = types.string,
             arguments = {
@@ -622,16 +622,6 @@ function g.test_custom_type_scalar_variables()
         variables = {field = '{"test": 123}'},
     }), {test_json_type = '{"test":123}'})
 
-    -- t.assert_equals(check_request([[
-    --     query($array: [Json]) {
-    --         test_json_type_list(
-    --             array: $array
-    --         )
-    --     }
-    -- ]], query_schema, {
-    --     variables = {array = {json.encode({test = 123})}},
-    -- }), {test_json_type_list = {'{"test":123}'}})
-
     t.assert_equals(check_request([[
         query($field: Json) {
             test_json_type(
@@ -641,6 +631,16 @@ function g.test_custom_type_scalar_variables()
     ]], query_schema, nil, nil, {
         variables = {field = box.NULL},
     }), {test_json_type = 'null'})
+
+    t.assert_equals(check_request([[
+        query($array: [Json]) {
+            test_json_type_list(
+                array: $array
+            )
+        }
+    ]], query_schema, nil, nil, {
+        variables = {array = {json.encode({test = 123})}},
+    }), {test_json_type_list = {'{"test":123}'}})
 
     t.assert_equals(check_request([[
         query {


### PR DESCRIPTION
Before this PR custom scalar that is actually a map (hack used to have an abilty to pass or to return json argument) can't be used. This PR fixes this misbehaviour.