### PR TITLE
Fix silently cast huge cdata numbers to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Accept a cdata number as value of a Float variable and forbid NaN and Inf`
 - `Fix coerce scalar list variables`
 - `Fix returning gapped arrays`
+- `Fix silently cast huge cdata numbers to null`
 
 ## 0.0.8
 

--- a/graphqlapi/graphql/types.lua
+++ b/graphqlapi/graphql/types.lua
@@ -289,7 +289,8 @@ local function isLong(value)
     if ffi.istype('int64_t', value) then
       return true
     elseif ffi.istype('uint64_t', value) then
-      return value < 2^63
+      -- return value < 2^63
+      return true
     end
   end
 
@@ -299,7 +300,7 @@ end
 local function coerceLong(value)
   if value ~= nil then
     value = tonumber64(value)
-    if not isLong(value) then return end
+    --if not isLong(value) then return end
   end
 
   return value

--- a/test/integration/graphql_integration_test.lua
+++ b/test/integration/graphql_integration_test.lua
@@ -97,7 +97,7 @@ function g.test_variables()
     local function callback(_, args)
         local result = ''
         for _, tuple in ipairs(getmetatable(args).__index) do
-            result = result .. tuple.value
+            result = result .. tostring(tuple.value)
         end
         return result
     end
@@ -185,10 +185,10 @@ function g.test_variables()
     )
 
     t.assert_error_msg_equals(
-            'Could not coerce value "18446744073709551614" to type "Long"',
+            'Could not coerce value "18446744073709551617" to type "Long"',
             function()
                 check_request([[
-                    query { test(arg: "", arg4: 18446744073709551614) }
+                    query { test(arg: "", arg4: 18446744073709551617) }
                 ]], query_schema)
             end
     )
@@ -2140,4 +2140,38 @@ function g.test_gapped_arrays_output()
         t.assert_type(res, 'table')
         t.assert_equals(json.encode(res.test), json.encode(v))
     end
+end
+
+function g.test_huge_cdata_number()
+    local query = [[
+       query ($x: Long!) { test(arg: $x) }
+   ]]
+
+   local function callback(_, args)
+       return args[1].value
+   end
+
+   local query_schema = {
+       ['test'] = {
+           kind = types.long.nonNull,
+           arguments = {
+               arg = types.long.nonNull,
+           },
+           resolve = callback,
+       }
+   }
+
+   local test_values = {
+       {4503599627370495ULL, "{\"test\":4503599627370495}"},
+       {9223372036854775807ULL, "{\"test\":9223372036854775807}"},
+       {-1LL, "{\"test\":-1}"},
+       {-1ULL, "{\"test\":18446744073709551615}"}}
+
+   for _, v in ipairs(test_values) do
+       local variables = {x = v[1]}
+       local res = check_request(query, query_schema, nil, nil, {variables = variables})
+       t.assert_type(res, 'table')
+       t.assert_equals(res.test, v[1])
+       t.assert_equals(json.encode(res), v[2])
+   end
 end


### PR DESCRIPTION
Before this PR one can't return 1ULL in types.long field. This PR fixes this misbehaviour.