### PR TITLE
Fix map custom type serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `Fix returning gapped arrays`
 - `Fix silently cast huge cdata numbers to null`
 - `Fix arguments and variables nullability validation`
+- `Fix Map (custom scalar type) - prevent dual jason.encode in some cases`
 
 ## 0.0.8
 

--- a/graphqlapi/types.lua
+++ b/graphqlapi/types.lua
@@ -138,7 +138,12 @@ types.map = types.scalar{
     description = 'Type to process any data in JSON format',
     specifiedByURL = 'https://github.com/tarantool/graphqlapi/wiki/Map',
     serialize = function(value)
-        return json.encode(value)
+        if type(value) ~= 'string' then
+            return json.encode(value)
+        else
+            -- in some cases need to prevent dual json.encode
+            return value
+        end
     end,
     parseValue = function(value)
         if type(value) == 'string' then


### PR DESCRIPTION
This PR fixes dual json.encode in some cases for custom scalar 'Map'