### PR TITLE
Release 0.0.9

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           tarantool-version: '2.8'
 
+      - run: cmake .
       - run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - run: tarantoolctl rocks new_version --tag $TAG
       - run: tarantoolctl rocks make graphqlapi-$TAG-1.rockspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.9
 
 - `Fix is_array() not working properly`
 - `Accept a cdata number as value of a Float variable and forbid NaN and Inf`
@@ -20,6 +20,7 @@
 - `Add utils.find() helper`
 - `Use cmake build type instead builtin`
 - `Add cluster.get_candidates() method`
+- `update examples dependencies: graphqlide@0.0.19 ->  graphqlide@0.0.21, graphqlapi@0.0.8 -> graphqlapi@0.0.9, graphqlapi-helpers@0.0.8 -> graphqlapi-helpers@0.0.9`
 
 ## 0.0.8
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_custom_target(lint
 )
 
 add_custom_target(test
+  COMMAND cmake .
   COMMAND .rocks/bin/luacheck .
   COMMAND rm -f tmp/luacov*
   COMMAND .rocks/bin/luatest --verbose --coverage --shuffle group

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Module based on:
 - [Tarantool VShard 0.1.19+](https://github.com/tarantool/vshard)
 - [Tarantool Checks 3.1.0+](https://github.com/tarantool/checks)
 - [Tarantool Errors 2.2.1+](https://github.com/tarantool/errors)
-- [Tarantool GraphQLIDE 0.0.20+](https://github.com/tarantool/graphqlide)
+- [Tarantool GraphQLIDE 0.0.21+](https://github.com/tarantool/graphqlide)
 
 **CAUTION:** Since this module is under heavy development it is not recommended to use on production environments and also API and functionality in future releases may be changed without backward compatibility!
 

--- a/examples/cartridge-full/README.md
+++ b/examples/cartridge-full/README.md
@@ -2,9 +2,9 @@
 
 This Example shows mostly all base capabilities of using the following set of modules:
 
-- [Tarantool GraphQLIDE 0.0.20+](https://github.com/tarantool/graphqlide)
-- [Tarantool GraphQLAPI 0.0.8+](https://github.com/tarantool/graphqlapi)
-- [Tarantool GraphQLAPI Helpers 0.0.8+](https://github.com/tarantool/graphqlapi-helpers) - this particular module available only in Tarantool Enterprise SDK bundle
+- [Tarantool GraphQLIDE 0.0.21+](https://github.com/tarantool/graphqlide)
+- [Tarantool GraphQLAPI 0.0.9+](https://github.com/tarantool/graphqlapi)
+- [Tarantool GraphQLAPI Helpers 0.0.9+](https://github.com/tarantool/graphqlapi-helpers) - this particular module available only in Tarantool Enterprise SDK bundle
 
 ## Quick start
 

--- a/examples/cartridge-full/cartridge.pre-build
+++ b/examples/cartridge-full/cartridge.pre-build
@@ -11,10 +11,10 @@ tarantoolctl rocks remove graphqlide --force
 tarantoolctl rocks remove graphqlapi --force
 tarantoolctl rocks remove graphqlapi-helpers --force
 
-tarantoolctl rocks install graphqlide 0.0.20
-tarantoolctl rocks install graphqlapi 0.0.8
+tarantoolctl rocks install graphqlide 0.0.21
+tarantoolctl rocks install graphqlapi 0.0.9
 
-GRAPHQLAPI_HELPERS_ROCK="${TARANTOOL_ENTERPRISE}/beta-rocks/graphqlapi-helpers-0.0.8-1.all.rock"
+GRAPHQLAPI_HELPERS_ROCK="${TARANTOOL_ENTERPRISE}/beta-rocks/graphqlapi-helpers-0.0.9-1.all.rock"
 if [ -f $GRAPHQLAPI_HELPERS_ROCK ]; then
     tarantoolctl rocks install "${GRAPHQLAPI_HELPERS_ROCK}"
 fi

--- a/examples/cartridge-simple/README.md
+++ b/examples/cartridge-simple/README.md
@@ -2,9 +2,9 @@
 
 This Example shows simple and quite easy way of howto use set of modules in application:
 
-- [Tarantool GraphQLIDE 0.0.20+](https://github.com/tarantool/graphqlide)
-- [Tarantool GraphQLAPI 0.0.8+](https://github.com/tarantool/graphqlapi)
-- [Tarantool GraphQLAPI Helpers 0.0.8+](https://github.com/tarantool/graphqlapi-helpers) - this particular module available only in Tarantool Enterprise SDK bundle
+- [Tarantool GraphQLIDE 0.0.21+](https://github.com/tarantool/graphqlide)
+- [Tarantool GraphQLAPI 0.0.9+](https://github.com/tarantool/graphqlapi)
+- [Tarantool GraphQLAPI Helpers 0.0.9+](https://github.com/tarantool/graphqlapi-helpers) - this particular module available only in Tarantool Enterprise SDK bundle
 
 ## Quick start
 

--- a/examples/cartridge-simple/cartridge.pre-build
+++ b/examples/cartridge-simple/cartridge.pre-build
@@ -11,10 +11,10 @@ tarantoolctl rocks remove graphqlide --force
 tarantoolctl rocks remove graphqlapi --force
 tarantoolctl rocks remove graphqlapi-helpers --force
 
-tarantoolctl rocks install graphqlide 0.0.20
-tarantoolctl rocks install graphqlapi 0.0.8
+tarantoolctl rocks install graphqlide 0.0.21
+tarantoolctl rocks install graphqlapi 0.0.9
 
-GRAPHQLAPI_HELPERS_ROCK="${TARANTOOL_ENTERPRISE}/beta-rocks/graphqlapi-helpers-0.0.8-1.all.rock"
+GRAPHQLAPI_HELPERS_ROCK="${TARANTOOL_ENTERPRISE}/beta-rocks/graphqlapi-helpers-0.0.9-1.all.rock"
 if [ -f $GRAPHQLAPI_HELPERS_ROCK ]; then
     tarantoolctl rocks install "${GRAPHQLAPI_HELPERS_ROCK}"
 fi


### PR DESCRIPTION
Release 0.0.9 contains the following changes:
- `Fix is_array() not working properly`
- `Accept a cdata number as value of a Float variable and forbid NaN and Inf`
- `Fix coerce scalar list variables`
- `Fix returning gapped arrays`
- `Fix silently cast huge cdata numbers to null`
- `Fix arguments and variables nullability validation`
- `Fix Map (custom scalar type) - prevent dual json.encode in some cases`
- `Remove sharding functions helpers (ddl 1.6+ now fully support custom sharding functions)`
- `Update dependencies to latest`
- `Add GraphQL over IPROTO feature`
- `Fix schema caching not work`
- `Add bucket_id wrapper`
- `Rename schemas.schemas_list() to schemas.list()`
- `Fix GraphQLIDE endpoints not registered in some cases`
- `Add operations.get_operation_fields() to extract operation requested fields`
- `Add utils.find() helper`
- `Use cmake build type instead builtin`
- `Add cluster.get_candidates() method`
- `update examples dependencies: graphqlide@0.0.19 ->  graphqlide@0.0.21, graphqlapi@0.0.8 -> graphqlapi@0.0.9, graphqlapi-helpers@0.0.8 -> graphqlapi-helpers@0.0.9`