### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,16 @@ on:
     tags: ['*']
 
 jobs:
+  version-check:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'graphqlapi'
+
   publish-scm-1:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
@@ -18,6 +28,7 @@ jobs:
 
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
+    needs: version-check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,4 @@ build.luarocks/
 *.rock
 CTestTestfile.cmake
 build.luarocks
-graphqlapi/VERSION.lua
 Makefile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- `Сhange versioning support`
+
 ## 0.0.9
 
 - `Fix is_array() not working properly`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,26 +22,6 @@ file(GLOB_RECURSE LUA_DOCS
   "${CMAKE_CURRENT_SOURCE_DIR}/docs/*.md"
 )
 
-## VERSION ####################################################################
-###############################################################################
-
-execute_process(
-  COMMAND git describe --tags --always
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  OUTPUT_VARIABLE GIT_DESCRIBE
-  ERROR_QUIET
-)
-
-if (NOT GIT_DESCRIBE)
-  set(GIT_DESCRIBE "unknown")
-endif()
-
-configure_file (
-  "${PROJECT_SOURCE_DIR}/graphqlapi/VERSION.lua.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/graphqlapi/VERSION.lua"
-)
-
 ## Custom targets #############################################################
 ###############################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,6 @@ add_custom_target(pack
 )
 
 add_custom_target(deps
-  COMMAND tarantoolctl rocks install cartridge 2.7.4
   COMMAND tarantoolctl rocks install luatest 0.5.7
   COMMAND tarantoolctl rocks install luacov 0.13.0
   COMMAND tarantoolctl rocks install luacheck 0.26.0

--- a/deps.sh
+++ b/deps.sh
@@ -3,9 +3,6 @@
 
 set -e
 
-# Module dependencies:
-tarantoolctl rocks install cartridge 2.7.4
-
 # Test dependencies:
 tarantoolctl rocks install luatest 0.5.7
 tarantoolctl rocks install luacov 0.13.0

--- a/graphqlapi-scm-1.rockspec
+++ b/graphqlapi-scm-1.rockspec
@@ -17,6 +17,7 @@ dependencies = {
     'http ~> 1',
     'errors ~> 2',
     'vshard ~> 0.1',
+    'cartridge ~> 2',
 }
 build = {
     type = 'cmake',

--- a/graphqlapi.lua
+++ b/graphqlapi.lua
@@ -594,4 +594,5 @@ return {
 
     -- version
     VERSION = VERSION,
+    _VERSION = VERSION,
 }

--- a/graphqlapi/VERSION.lua
+++ b/graphqlapi/VERSION.lua
@@ -1,0 +1,4 @@
+-- Сontains the module version.
+-- Requires manual update in case of release commit.
+
+return '0.0.9'

--- a/graphqlapi/VERSION.lua.in
+++ b/graphqlapi/VERSION.lua.in
@@ -1,3 +1,0 @@
-#!/usr/bin/env tarantool
-
-return "@GIT_DESCRIBE@"

--- a/test/unit/graphqlapi_test.lua
+++ b/test/unit/graphqlapi_test.lua
@@ -626,10 +626,7 @@ g.test_schema_caching = function()
 end
 
 g.test_version = function()
-    local handle = io.popen('git describe --tags --always')
-    local version = handle:read("*a"):gsub('\n*', '')
-    handle:close()
-    t.assert_equals(require('graphqlapi').VERSION, version)
+    t.assert_type(require('graphqlapi')._VERSION, 'string')
 end
 
 local function stub_data()


### PR DESCRIPTION
Add versioning support, now the module api has `_VERSION` hardcoded variable. Is part of the task [1].

1. https://github.com/tarantool/roadmap-internal/issues/204