### PR TITLE
Release 0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 0.0.10
 
 - `Сhange versioning support`
 

--- a/graphqlapi/VERSION.lua
+++ b/graphqlapi/VERSION.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '0.0.9'
+return '0.0.10'


### PR DESCRIPTION
### Overview

This release introduced new module versioning strategy (see `require('graphqlapi')._VERSION API).

### Changes
- Сhange versioning support