### PR TITLE
release 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.0.11
 
 - `Allow to work with ddl 1.7.0 and newer`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `Allow to work with ddl 1.7.0 and newer`
+
 ## 0.0.10
 
 - `Сhange versioning support`

--- a/graphqlapi-scm-1.rockspec
+++ b/graphqlapi-scm-1.rockspec
@@ -13,7 +13,7 @@ description = {
 dependencies = {
     'lua >= 5.1',
     'luagraphqlparser ~> 0',
-    'ddl ~> 1.6',
+    'ddl >= 1.6',
     'http ~> 1',
     'errors ~> 2',
     'vshard ~> 0.1',

--- a/graphqlapi/VERSION.lua
+++ b/graphqlapi/VERSION.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '0.0.10'
+return '0.0.11'


### PR DESCRIPTION
Now we cannot build SDK with ddl 1.7.0 since, after ddl is bumped from 1.6.x to 1.7.0, `graphqlapi` is no longer installable due to dependency lock.

### Overview

This release changes the rock dependency to allow module to be used with ddl 1.7.0 and newer.